### PR TITLE
bump image crate to 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ axum = { version = "0.7", optional = true, features = ["macros"] }
 tower = { version = "0.4", optional = true }
 tower-http = { version = "0.5", features = ["fs"], optional = true }
 
-image = { version = "0.24", optional = true}
+image = { version = "0.25", optional = true}
 webp = { version= "0.2", optional = true}
 serde = { version = "1.0", features = ["derive"] }
 serde_qs = "0.12"


### PR DESCRIPTION
When running `cargo leptos watch` inside the example, cargo was complaining that the crate `image` was being used twice with 2 conflicting versions (0.24.9 and 0.25.1)

By requesting image 0.25 everything compiles and works