### PR TITLE
Pin webp 0.2.7 + image 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ axum = { version = "0.7", optional = true, features = ["macros"] }
 tower = { version = "0.4", optional = true }
 tower-http = { version = "0.5", features = ["fs"], optional = true }
 
-image = { version = "0.24", optional = true}
-webp = { version= "0.2", optional = true}
+image = { version = "0.25", optional = true}
+webp = { version= "0.2.7", optional = true}
 serde = { version = "1.0", features = ["derive"] }
 serde_qs = "0.12"
 thiserror = { version = "1", optional = true }


### PR DESCRIPTION
webp 0.27 got released, which depends on image 0.25.

Using these pins I got my images back on screen, thanks!

`cargo build` failed using `leptos_image = "0.2.0"` with the following.
<details><summary>Details</summary>
<code>

➤ cargo build
    Blocking waiting for file lock on package cache
    Updating crates.io index
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
   Compiling num-traits v0.2.18
   Compiling jpeg-decoder v0.3.1
   Compiling tiff v0.9.1
   Compiling hdrhistogram v7.5.4
   Compiling image v0.25.1
   Compiling image v0.24.9
   Compiling chrono v0.4.37
   Compiling tower v0.4.13
   Compiling webp v0.2.7
   Compiling axum v0.7.5
   Compiling tower-http v0.5.2
   Compiling server_fn v0.6.10
   Compiling leptos_server v0.6.10
   Compiling leptos_dom v0.6.10
   Compiling leptos v0.6.10
   Compiling leptos_meta v0.6.10
   Compiling leptos_integration_utils v0.6.10
   Compiling leptos_router v0.6.10
   Compiling leptos_axum v0.6.10
   Compiling leptos_image v0.2.0
error[E0308]: mismatched types
   --> /Users/roel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/leptos_image-0.2.0/src/optimizer.rs:174:56
    |
174 |             let encoder: Encoder = Encoder::from_image(&new_img).unwrap();
    |                                    ------------------- ^^^^^^^^ expected `image::dynimage::DynamicImage`, found `DynamicImage`
    |                                    |
    |                                    arguments to this function are incorrect
    |
    = note: `DynamicImage` and `image::dynimage::DynamicImage` have similar names, but are actually distinct types
note: `DynamicImage` is defined in crate `image`
   --> /Users/roel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/image-0.24.9/src/dynimage.rs:55:1
    |
55  | pub enum DynamicImage {
    | ^^^^^^^^^^^^^^^^^^^^^
note: `image::dynimage::DynamicImage` is defined in crate `image`
   --> /Users/roel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/image-0.25.1/src/dynimage.rs:50:1
    |
50  | pub enum DynamicImage {
    | ^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `image` are being used?
note: associated function defined here
   --> /Users/roel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/webp-0.2.7/src/encoder.rs:29:12
    |
29  |     pub fn from_image(image: &'a DynamicImage) -> Result<Self, &str> {
    |            ^^^^^^^^^^

error[E0308]: mismatched types
   --> /Users/roel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/leptos_image-0.2.0/src/optimizer.rs:211:48
    |
211 |     let encoder: Encoder = Encoder::from_image(&img).unwrap();
    |                            ------------------- ^^^^ expected `image::dynimage::DynamicImage`, found `DynamicImage`
    |                            |
    |                            arguments to this function are incorrect
    |
    = note: `DynamicImage` and `image::dynimage::DynamicImage` have similar names, but are actually distinct types
note: `DynamicImage` is defined in crate `image`
   --> /Users/roel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/image-0.24.9/src/dynimage.rs:55:1
    |
55  | pub enum DynamicImage {
    | ^^^^^^^^^^^^^^^^^^^^^
note: `image::dynimage::DynamicImage` is defined in crate `image`
   --> /Users/roel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/image-0.25.1/src/dynimage.rs:50:1
    |
50  | pub enum DynamicImage {
    | ^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `image` are being used?
note: associated function defined here
   --> /Users/roel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/webp-0.2.7/src/encoder.rs:29:12
    |
29  |     pub fn from_image(image: &'a DynamicImage) -> Result<Self, &str> {
    |            ^^^^^^^^^^

For more information about this error, try `rustc --explain E0308`.
error: could not compile `leptos_image` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...

</code>
</details> 