### PR TITLE
Filter type and Resize strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,22 +20,22 @@ web-sys = { version = "0.3", optional = true, features = ["HtmlImageElement"]}
 
 tokio = { version = "1", features = ["rt-multi-thread", "rt", "fs"], optional = true }
 axum = { version = "0.7", optional = true, features = ["macros"] }
-tower = { version = "0.4", optional = true }
-tower-http = { version = "0.5", features = ["fs"], optional = true }
+tower = { version = "0.5", optional = true }
+tower-http = { version = "0.6", features = ["fs"], optional = true }
 
-image = { version = "0.24", optional = true}
-webp = { version= "0.2", optional = true}
+image = { version = "0.25", optional = true}
+webp = { version= "0.3", optional = true}
 serde = { version = "1.0", features = ["derive"] }
-serde_qs = "0.12"
+serde_qs = "0.13"
 thiserror = { version = "1", optional = true }
-base64 = "0.21"
+base64 = "0.22"
 tracing = { version = "0.1", optional = true }
-dashmap = { version = "5", optional = true }
+dashmap = { version = "6", optional = true }
 
 [features]
-ssr = [ 
+ssr = [
     "leptos_router/ssr", "leptos_meta/ssr" , "leptos/ssr",
-    "dep:webp", "dep:image", 
+    "dep:webp", "dep:image",
     "dep:tokio", "dep:axum", "dep:tower", "dep:tower-http",
     "dep:tracing", "dep:dashmap", "dep:thiserror"
 ]

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,5 +1,5 @@
-use std::str::FromStr;
 use crate::optimizer::*;
+use std::str::FromStr;
 
 use leptos::*;
 use leptos_meta::Link;
@@ -10,7 +10,7 @@ use leptos_meta::Link;
 /// Image component for rendering optimized static images.
 /// Images MUST be static. Will not work with dynamic images.
 #[component]
-pub fn Image<'a>(
+pub fn Image(
     /// Image source. Should be path relative to root.
     #[prop(into)]
     src: String,
@@ -22,11 +22,11 @@ pub fn Image<'a>(
     #[prop(default = 75_u8)]
     quality: u8,
     /// Filter type for the conversion : Nearest, Triangle, CatmullRom, Gaussian, Lanczos3
-    #[prop(default = "catmullrom")]
-    filter: &'a str,
+    #[prop(default = Filter::CatmullRom)]
+    filter: Filter,
     /// Resize type for the conversion : Fit, Fill, Cover
-    #[prop(default = "fit")]
-    resize_type: &'a str,
+    #[prop(default = ResizeType::Fit)]
+    resize_type: ResizeType,
     /// Will add blur image to head if true.
     #[prop(default = false)]
     blur: bool,
@@ -67,10 +67,10 @@ pub fn Image<'a>(
             src: src.clone(),
             option: CachedImageOption::Resize(Resize {
                 quality,
-                filter: filter.parse().unwrap_or_default(),
+                filter,
                 width,
                 height,
-                resize_type: resize_type.parse().unwrap_or_default(),
+                resize_type,
             }),
         }
     };
@@ -156,8 +156,8 @@ fn CacheImage(
                 format!("url('{}')", svg_url)
             }
         };
-        let style= format!(
-        "color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:{background_image};",
+        let style = format!(
+            "color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:{background_image};",
         );
 
         style

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,6 +1,4 @@
 use crate::optimizer::*;
-use std::str::FromStr;
-
 use leptos::*;
 use leptos_meta::Link;
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -10,7 +10,7 @@ use leptos_meta::Link;
 /// Image component for rendering optimized static images.
 /// Images MUST be static. Will not work with dynamic images.
 #[component]
-pub fn Image(
+pub fn Image<'a>(
     /// Image source. Should be path relative to root.
     #[prop(into)]
     src: String,
@@ -23,10 +23,10 @@ pub fn Image(
     quality: u8,
     /// Filter type for the conversion : Nearest, Triangle, CatmullRom, Gaussian, Lanczos3
     #[prop(default = "catmullrom")]
-    filter: impl Into<Filter>,
+    filter: &'a str,
     /// Resize type for the conversion : Fit, Fill, Cover
     #[prop(default = "fit")]
-    resize_type: impl Into<ResizeType>,
+    resize_type: &'a str,
     /// Will add blur image to head if true.
     #[prop(default = false)]
     blur: bool,
@@ -67,10 +67,10 @@ pub fn Image(
             src: src.clone(),
             option: CachedImageOption::Resize(Resize {
                 quality,
-                filter: filter.into(),
+                filter: filter.parse().unwrap_or_default(),
                 width,
                 height,
-                resize_type: resize_type.into(),
+                resize_type: resize_type.parse().unwrap_or_default(),
             }),
         }
     };

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use crate::optimizer::*;
 
 use leptos::*;
@@ -21,11 +22,11 @@ pub fn Image(
     #[prop(default = 75_u8)]
     quality: u8,
     /// Filter type for the conversion : Nearest, Triangle, CatmullRom, Gaussian, Lanczos3
-    #[prop(default = Filter::CatmullRom)]
-    filter: Filter,
+    #[prop(default = "catmullrom")]
+    filter: impl Into<Filter>,
     /// Resize type for the conversion : Fit, Fill, Cover
-    #[prop(default = ResizeType::Fit)]
-    resize_type: ResizeType,
+    #[prop(default = "fit")]
+    resize_type: impl Into<ResizeType>,
     /// Will add blur image to head if true.
     #[prop(default = false)]
     blur: bool,

--- a/src/image.rs
+++ b/src/image.rs
@@ -20,6 +20,12 @@ pub fn Image(
     /// Image quality. 0-100.
     #[prop(default = 75_u8)]
     quality: u8,
+    /// Filter type for the conversion : Nearest, Triangle, CatmullRom, Gaussian, Lanczos3
+    #[prop(default = Filter::CatmullRom)]
+    filter: Filter,
+    /// Resize type for the conversion : Fit, Fill, Cover
+    #[prop(default = ResizeType::Fit)]
+    resize_type: ResizeType,
     /// Will add blur image to head if true.
     #[prop(default = false)]
     blur: bool,
@@ -60,8 +66,10 @@ pub fn Image(
             src: src.clone(),
             option: CachedImageOption::Resize(Resize {
                 quality,
+                filter: filter.into(),
                 width,
                 height,
+                resize_type: resize_type.into(),
             }),
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! Here’s how you can integrate the Image Optimizer into your Leptos application:
 //!
 //! ```
-//!     
+//!
 //! # use leptos_image::*;
 //! # use leptos::*;
 //! # use axum::*;
@@ -110,6 +110,7 @@ mod routes;
 pub use image::*;
 #[cfg(feature = "ssr")]
 pub use optimizer::ImageOptimizer;
+pub use optimizer::{Filter, ResizeType};
 pub use provider::*;
 #[cfg(feature = "ssr")]
 pub use routes::*;

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1,5 +1,5 @@
-use std::str::FromStr;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 /// ImageOptimizer enables image optimization and caching.
 #[cfg(feature = "ssr")]
@@ -160,12 +160,12 @@ where
 
     match config {
         CachedImageOption::Resize(Resize {
-            width,
-            height,
-            quality,
-            filter,
-            resize_type,
-        }) => {
+                                      width,
+                                      height,
+                                      quality,
+                                      filter,
+                                      resize_type,
+                                  }) => {
             let mut img = image::open(source_path)?;
             resize_type.resize(&mut img, width, height, filter);
 
@@ -262,7 +262,7 @@ pub(crate) enum CachedImageOption {
 }
 
 #[derive(Clone, Debug, PartialEq, Default, Eq, Deserialize, Serialize, Hash)]
-pub(crate) enum ResizeType{
+pub enum ResizeType {
     #[default]
     Fit,
     Fill,
@@ -270,13 +270,13 @@ pub(crate) enum ResizeType{
 }
 
 #[cfg(feature = "ssr")]
-impl ResizeType{
+impl ResizeType {
     pub(crate) fn resize(&self, img: &mut image::DynamicImage, width: u32, height: u32, filter: Filter) {
-       match self {
-           ResizeType::Fit => {*img = img.resize_exact(width, height, filter.into())}
-           ResizeType::Fill => {*img = img.resize_to_fill(width, height, filter.into())}
-           ResizeType::Cover => {*img = img.thumbnail(width, height)}
-       }
+        match self {
+            ResizeType::Fit => { *img = img.resize_exact(width, height, filter.into()) }
+            ResizeType::Fill => { *img = img.resize_to_fill(width, height, filter.into()) }
+            ResizeType::Cover => { *img = img.thumbnail(width, height) }
+        }
     }
 }
 
@@ -294,7 +294,7 @@ impl FromStr for ResizeType {
 }
 
 #[derive(Clone, Debug, PartialEq, Default, Eq, Deserialize, Serialize, Hash)]
-pub(crate) enum Filter {
+pub enum Filter {
     #[default]
     CatmullRom,
     Gaussian,
@@ -446,7 +446,7 @@ where
     P: AsRef<std::ffi::OsStr>,
 {
     match std::path::Path::new(&path).parent() {
-        Some(p) if (!(p).exists()) => std::fs::create_dir_all(p),
+        Some(p) if (!(p).exists()) => tokio::fs::create_dir_all(p),
         Some(_) => Result::Ok(()),
         None => Result::Ok(()),
     }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -265,8 +265,8 @@ pub(crate) enum CachedImageOption {
 pub enum ResizeType {
     #[default]
     Fit,
-    Fill,
     Cover,
+    Thumbnail,
 }
 
 #[cfg(feature = "ssr")]
@@ -274,24 +274,12 @@ impl ResizeType {
     pub(crate) fn resize(&self, img: &mut image::DynamicImage, width: u32, height: u32, filter: Filter) {
         match self {
             ResizeType::Fit => { *img = img.resize_exact(width, height, filter.into()) }
-            ResizeType::Fill => { *img = img.resize_to_fill(width, height, filter.into()) }
-            ResizeType::Cover => { *img = img.thumbnail(width, height) }
+            ResizeType::Cover => { *img = img.resize_to_fill(width, height, filter.into()) }
+            ResizeType::Thumbnail => { *img = img.thumbnail(width, height) }
         }
     }
 }
 
-impl FromStr for ResizeType {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "fit" => Ok(ResizeType::Fit),
-            "fill" => Ok(ResizeType::Fill),
-            "cover" => Ok(ResizeType::Cover),
-            _ => Err(()),
-        }
-    }
-}
 
 #[derive(Clone, Debug, PartialEq, Default, Eq, Deserialize, Serialize, Hash)]
 pub enum Filter {
@@ -316,20 +304,6 @@ impl From<Filter> for image::imageops::FilterType {
     }
 }
 
-impl FromStr for Filter {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "catmullrom" => Ok(Filter::CatmullRom),
-            "gaussian" => Ok(Filter::Gaussian),
-            "nearest" => Ok(Filter::Nearest),
-            "triangle" => Ok(Filter::Triangle),
-            "lanczos3" => Ok(Filter::Lanczos3),
-            _ => Err(()),
-        }
-    }
-}
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, Hash)]
 #[serde(rename = "r")]

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use serde::{Deserialize, Serialize};
 
 /// ImageOptimizer enables image optimization and caching.
 #[cfg(feature = "ssr")]
@@ -446,7 +446,7 @@ where
     P: AsRef<std::ffi::OsStr>,
 {
     match std::path::Path::new(&path).parent() {
-        Some(p) if (!(p).exists()) => tokio::fs::create_dir_all(p),
+        Some(p) if (!(p).exists()) => std::fs::create_dir_all(p),
         Some(_) => Result::Ok(()),
         None => Result::Ok(()),
     }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 /// ImageOptimizer enables image optimization and caching.

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 /// ImageOptimizer enables image optimization and caching.
@@ -279,6 +280,19 @@ impl ResizeType{
     }
 }
 
+impl FromStr for ResizeType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "fit" => Ok(ResizeType::Fit),
+            "fill" => Ok(ResizeType::Fill),
+            "cover" => Ok(ResizeType::Cover),
+            _ => Err(()),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Default, Eq, Deserialize, Serialize, Hash)]
 pub(crate) enum Filter {
     #[default]
@@ -302,6 +316,20 @@ impl From<Filter> for image::imageops::FilterType {
     }
 }
 
+impl FromStr for Filter {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "catmullrom" => Ok(Filter::CatmullRom),
+            "gaussian" => Ok(Filter::Gaussian),
+            "nearest" => Ok(Filter::Nearest),
+            "triangle" => Ok(Filter::Triangle),
+            "lanczos3" => Ok(Filter::Lanczos3),
+            _ => Err(()),
+        }
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, Hash)]
 #[serde(rename = "r")]


### PR DESCRIPTION
Added the ability to define the filter type (Cover, Thumbnail, Fit) and resizing strategy (CatmullRom, Lanczos3, Nearest, Triangle, Gaussian) from the client. 

I did not fix the std::fs to tokio::fs for now.